### PR TITLE
Refine hero styling and highlight chips

### DIFF
--- a/Components/Pages/Home.razor
+++ b/Components/Pages/Home.razor
@@ -3,28 +3,28 @@
 
 <HeadContent>
     <title>Bipin Paul - ASP.NET Core, Blazor & Azure Cloud</title>
-    <meta name="description" content=".NET Core /.NET 9+ Developer with Expertise in Cloud Tech and Blazor. Passionate about learning new skills and exploring new challenges in backend/web development."/>
+    <meta name="description" content="Backend-focused .NET developer working on cloud systems and Blazor apps. I build clean APIs and keep platforms easy to run."/>
     <meta name="keywords" content="Bipin Paul, .NET, C#, ASP.NET Core, Blazor, Azure, Cloud, Developer, Docker, Cosmos DB, SQL Server, Angular"/>
     <meta name="author" content="Bipin Paul"/>
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website"/>
     <meta property="og:title" content="Bipin Paul - ASP.NET Core, Blazor & Azure Cloud"/>
-    <meta property="og:description" content=".NET Core /.NET 9+ Developer with Expertise in Cloud Tech and Blazor."/>
+    <meta property="og:description" content="Backend-focused .NET developer working on cloud systems and Blazor apps."/>
     <meta property="og:image" content="@(@WebsiteKeys.BlogPostUrl + "/" + "images/bipinpaul.jpeg")"/>
     <meta property="og:url" content="@WebsiteKeys.BlogPostUrl"/>
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:title" content="Bipin Paul - ASP.NET Core, Blazor & Azure Cloud"/>
-    <meta name="twitter:description" content=".NET Core /.NET 9+ Developer with Expertise in Cloud Tech and Blazor."/>
+    <meta name="twitter:description" content="Backend-focused .NET developer working on cloud systems and Blazor apps."/>
     <meta name="twitter:image" content="@(@WebsiteKeys.BlogPostUrl + "/" + "images/bipinpaul.jpeg")"/>
 </HeadContent>
 
 
 <!-- Hero Section -->
 <div class="py-8 lg:py-12">
-    <div class="flex flex-col lg:flex-row lg:items-center lg:gap-12">
+    <div class="flex flex-col lg:flex-row lg:items-center lg:gap-12 bg-background-secondary/50 border border-border rounded-xl p-6">
         <!-- Profile Card -->
         <div class="flex-shrink-0 mb-8 lg:mb-0">
             <img src="images/bipinpaul.jpeg" alt="Bipin Paul"
@@ -34,13 +34,29 @@
         <!-- Hero Text -->
         <div class="flex-1">
             <div class="space-y-4">
+                <p class="text-xs uppercase tracking-wider text-foreground-muted">
+                    Backend &amp; Cloud Developer
+                </p>
+
                 <h1 class="text-4xl lg:text-5xl xl:text-6xl font-extrabold tracking-tight text-foreground">
-                    Hey, I'm Bipin Paul
+                    Bipin Paul
                 </h1>
 
                 <p class="text-xl lg:text-2xl text-foreground-tertiary max-w-2xl">
-                    .NET Developer building backend services and web applications with Blazor and Azure Cloud
+                    .NET developer building cloud services and Blazor apps with a strong backend focus.
                 </p>
+
+                <div class="flex flex-wrap gap-2 text-sm text-foreground-secondary">
+                    <span class="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 bg-white/10">
+                        7+ years shipping production systems
+                    </span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 bg-white/10">
+                        Azure • Docker • CI/CD
+                    </span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 bg-white/10">
+                        APIs, integrations, and data
+                    </span>
+                </div>
 
                 <!-- Social Links -->
                 <div class="flex items-center gap-3 pt-2">
@@ -70,9 +86,9 @@
 <!-- About Section -->
 <div class="py-8 border-t border-border">
     <p class="text-lg text-foreground-tertiary mb-6 max-w-3xl">
-        I've spent the last 7+ years building web applications — from ERP and QMS systems to social platforms connecting communities.
-        My go-to stack is .NET Core and Blazor, and while I specialize in backend architecture and cloud solutions,
-        I'm comfortable working across the full stack when needed.
+        I help teams ship dependable systems that can grow from MVP to enterprise. Over the last 7+ years, I’ve worked on
+        ERP, QMS, and community platforms with an emphasis on performance, clarity, and long-term maintainability. My core
+        stack is .NET Core and Blazor, and I regularly collaborate across backend, infrastructure, and delivery.
     </p>
 
     <!-- What I Work With -->
@@ -154,12 +170,12 @@
     </div>
 
     <p class="text-foreground-tertiary max-w-2xl">
-        I believe software development is a craft that never stops evolving. I'm always learning new patterns,
-        trying new tools, and looking for the next interesting challenge.
+        I care about straightforward architecture, pragmatic engineering, and keeping systems easy to operate.
+        If it’s reliable and readable, we’re on the right track.
     </p>
 
     <p class="text-foreground mt-6 font-medium">
-        Let's build something great together.
+        Let’s build something solid.
     </p>
 </div>
 


### PR DESCRIPTION
### Motivation
- Make the hero feel warmer and more human by adding a framed layout and softer visual treatments. 
- Reduce marketing/AI-slogan tone in the hero and highlight chips by tightening copy and emphasizing practical experience. 
- Surface role/context immediately (eyebrow label) so visitors understand the focus at a glance. 

### Description
- Wrapped the hero in a subtle framed card by adding `bg-background-secondary/50 border border-border rounded-xl p-6` to the hero container. 
- Added an eyebrow label above the name (`Backend & Cloud Developer`) and removed the informal greeting so the heading displays the plain name. 
- Softened the highlight chips by changing their background to `bg-white/10`, adjusted text classes, and updated chip copy to read `7+ years shipping production systems`, `Azure • Docker • CI/CD`, and `APIs, integrations, and data`. 
- Minor copy adjustments in the About section and the closing line (now `Let’s build something solid.`) to reinforce a grounded, pragmatic tone. 

### Testing
- No automated build or runtime tests were executed because the environment does not have the `dotnet` CLI/runtime available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871b68ad588332a99b7388a0e9383c)