### PR TITLE
Target net10.0 and update BlazorStatic to 1.0.0-beta.17

### DIFF
--- a/bipinpaul.com.csproj
+++ b/bipinpaul.com.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorStatic" Version="1.0.0-beta.15" />
+    <PackageReference Include="BlazorStatic" Version="1.0.0-beta.17" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Move the project to .NET 10 for the latest runtime compatibility and update the BlazorStatic package to pick up recent fixes and features.

### Description
- Change `bipinpaul.com.csproj` `<TargetFramework>` from `net9.0` to `net10.0`.
- Bump `BlazorStatic` package reference in `bipinpaul.com.csproj` from `1.0.0-beta.15` to `1.0.0-beta.17`.
- Preserve existing content/Watch/CopyToOutputDirectory settings in the project file.

### Testing
- Queried NuGet for `BlazorStatic` versions with a Python script and confirmed `1.0.0-beta.17` is available (succeeded). 
- Ran `dotnet list package --outdated --include-prerelease` but it failed because `dotnet` is not available in the environment (failed).
- Ran `dotnet build` to validate the project but it failed because `dotnet` is not available in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871f679b14833282ce834c8ab15371)